### PR TITLE
Add `AffineTraversal.fromEnum`

### DIFF
--- a/Sources/FunOptics/AffineTraversal.swift
+++ b/Sources/FunOptics/AffineTraversal.swift
@@ -83,33 +83,49 @@ public func >>> <Whole, Part, Part2>(l: AffineTraversal<Whole, Part>, r: Prism<P
 
 // MARK: - Enum-property to AffineTraversal
 
-/// Makes `AffineTraversal` from enum-property (enum case's computed get-set property).
-///
-/// ## Example
-///
-/// ```
-/// struct EnumState {
-///     case pattern1(Int)
-///     ...
-///
-///     var pattern1: Int? { // Enum computed get-set property.
-///         get {
-///             guard case let .pattern1(value) = self else { return nil }
-///             return value
-///         }
-///         set {
-///             guard case .pattern1 = self, let newValue = newValue else { return }
-///             self = .pattern1(newValue)
-///         }
-///     }
-/// }
-///
-/// let affineTraversal: AffineTraversal<EnumState, Int> = fromEnumProperty(\EnumState.pattern1)
-/// ```
-///
-/// - SeeAlso: https://github.com/pointfreeco/swift-enum-properties
-///
-/// - Note: This is a workaround of Swift that is not able to create `Prism` from KeyPath syntax.
+extension AffineTraversal
+{
+    /// Makes `AffineTraversal` from enum-property (enum case's computed get-set property).
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// struct EnumState {
+    ///     case pattern1(Int)
+    ///     ...
+    ///
+    ///     var pattern1: Int? { // Enum computed get-set property.
+    ///         get {
+    ///             guard case let .pattern1(value) = self else { return nil }
+    ///             return value
+    ///         }
+    ///         set {
+    ///             guard case .pattern1 = self, let newValue = newValue else { return }
+    ///             self = .pattern1(newValue)
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// let affineTraversal: AffineTraversal<EnumState, Int> = fromEnumProperty(\EnumState.pattern1)
+    /// ```
+    ///
+    /// - SeeAlso: https://github.com/pointfreeco/swift-enum-properties
+    ///
+    /// - Note: This is a workaround of Swift that is not able to create `Prism` from KeyPath syntax.
+    public static func fromEnum(_ keyPath: WritableKeyPath<Whole, Part?>) -> AffineTraversal<Whole, Part>
+    {
+        .init(
+            tryGet: { $0[keyPath: keyPath] },
+            set: { whole, part in
+                var whole = whole
+                whole[keyPath: keyPath] = part
+                return whole
+            }
+        )
+    }
+}
+
+@available(*, deprecated, renamed: "AffineTraversal.fromEnum(_:)")
 public func fromEnumProperty<Whole, Part>(
     _ keyPath: WritableKeyPath<Whole, Part?>
 ) -> AffineTraversal<Whole, Part>


### PR DESCRIPTION
This PR deprecates `func fromEnumProperty` (free func) by replacing to `AffineTraversal.fromEnum` better namespace. 